### PR TITLE
typo修正

### DIFF
--- a/Utility/InstallUtil.php
+++ b/Utility/InstallUtil.php
@@ -749,7 +749,7 @@ EOF;
  */
 	public function saveSiteSetting($data = array()) {
 		$this->Language = ClassRegistry::init('M17n.Language');
-		$this->SiteSetting = ClassRegistry::init('SitManager.SiteSetting');
+		$this->SiteSetting = ClassRegistry::init('SiteManager.SiteSetting');
 
 		try {
 			$this->Language->begin();


### PR DESCRIPTION
xamppインストール時の内部エラー対応

### --- error.log

```
2017-01-23 00:24:44 Error: [MissingPluginException] Plugin SitManager could not be found.
Exception Attributes: array (
  'plugin' => 'SitManager',
)
Request URL: /install/init_site_setting?language=ja
Stack Trace:
#0 C:\projects\xampp\htdocs\vendors\cakephp\cakephp\lib\Cake\Core\App.php(227): CakePlugin::path('SitManager')
#1 C:\projects\xampp\htdocs\vendors\cakephp\cakephp\lib\Cake\Core\App.php(549): App::path('Model', 'SitManager')
#2 [internal function]: App::load('SiteSetting')
#3 [internal function]: spl_autoload_call('SiteSetting')
#4 C:\projects\xampp\htdocs\vendors\cakephp\cakephp\lib\Cake\Utility\ClassRegistry.php(146): class_exists('SiteSetting')
#5 C:\projects\xampp\htdocs\app\Plugin\Install\Utility\InstallUtil.php(752): ClassRegistry::init('SiteSetting')
#6 C:\projects\xampp\htdocs\app\Plugin\Install\Controller\InstallController.php(263): InstallUtil->saveSiteSetting(Array)
#7 [internal function]: InstallController->init_site_setting()
#8 C:\projects\xampp\htdocs\vendors\cakephp\cakephp\lib\Cake\Controller\Controller.php(491): ReflectionMethod->invokeArgs(Object(InstallController), Array)
#9 C:\projects\xampp\htdocs\vendors\cakephp\cakephp\lib\Cake\Routing\Dispatcher.php(193): Controller->invokeAction(Object(CakeRequest))
#10 C:\projects\xampp\htdocs\vendors\cakephp\cakephp\lib\Cake\Routing\Dispatcher.php(167): Dispatcher->_invoke(Object(InstallController), Object(CakeRequest))
#11 C:\projects\xampp\htdocs\app\webroot\index.php(106): Dispatcher->dispatch(Object(CakeRequest), Object(CakeResponse))
#12 {main}
```