### PR TITLE
下記の理由により、DBの初期化をInstallStartTaskではなく、CreateDatabaseTask内で行うように修正

### DIFF
--- a/Console/Command/Task/CreateDatabaseTask.php
+++ b/Console/Command/Task/CreateDatabaseTask.php
@@ -76,6 +76,17 @@ class CreateDatabaseTask extends InstallAppTask {
 	public function execute() {
 		parent::execute();
 
+		//database.phpの初期化処理
+		$configs = $this->InstallUtil->chooseDBByEnvironment();
+		if (! $this->InstallUtil->saveDBConf($configs)) {
+			$message = __d(
+				'install',
+				'Failed to write %s. Please check permission.',
+				array(APP . 'Config' . DS . 'database.php')
+			);
+			return $this->error($message);
+		}
+
 		//引数のセット
 		$this->__prepare();
 

--- a/Console/Command/Task/InstallStartTask.php
+++ b/Console/Command/Task/InstallStartTask.php
@@ -88,17 +88,6 @@ class InstallStartTask extends InstallAppTask {
 			);
 			return $this->error($message);
 		}
-
-		//database.phpの初期化処理
-		$configs = $this->InstallUtil->chooseDBByEnvironment();
-		if (! $this->InstallUtil->saveDBConf($configs)) {
-			$message = __d(
-				'install',
-				'Failed to write %s. Please check permission.',
-				array(APP . 'Config' . DS . 'database.php')
-			);
-			return $this->error($message);
-		}
 	}
 
 /**


### PR DESCRIPTION
シェルでインストールする際、databasa.phpの設定内容は変えずに、application.ymlだけを更新したいことがあるため。