### PR TITLE
fix(migration): Blocks requires Rooms Tables

### DIFF
--- a/Utility/InstallUtil.php
+++ b/Utility/InstallUtil.php
@@ -210,7 +210,7 @@ class InstallUtil {
  */
 	public $migrationPriorityPlugins = array(
 		'Files', 'Users', 'NetCommons', 'M17n', 'DataTypes', 'PluginManager',
-		'Roles', 'Mails', 'SiteManager', 'Blocks', 'Boxes'
+		'Roles', 'Mails', 'SiteManager', 'Rooms', 'Blocks', 'Boxes'
 	);
 
 /**


### PR DESCRIPTION
## なぜやるのか
初期化の Migration 時に
```
Info: [migration]   ---------------------------------------------------------------
Info: [migration]   There was an error during a migration.
Info: [migration]    The error was: 'Table edm_roles_rooms for model RolesRoom was not found in datasource master.'
Info: [migration]    You must resolve the issue manually and try again.
Info: [migration]   All migrations have completed.
Info: [migration]
Info: [migration] Successfully migrated "Blocks" for master connection
```

というエラーがこっそり表示されているので、Blocks の前に Rooms を migration するようにしました
